### PR TITLE
add-domain

### DIFF
--- a/smart_carwash/README.md
+++ b/smart_carwash/README.md
@@ -79,13 +79,13 @@ smart_carwash/
    >
    > Для получения доверенного SSL сертификата можно использовать один из скриптов:
    > ```bash
-   > # Для получения сертификата от Let's Encrypt с использованием сервиса nip.io (работает в РФ)
+   > # Для получения сертификата от Let's Encrypt для домена h2o-nsk.ru (работает в РФ)
    > ./get_letsencrypt_ssl.sh
    > 
    > # Для получения сертификата от ZeroSSL (может не работать в РФ)
    > ./get_trusted_ssl.sh
    > ```
-   > Скрипт `get_letsencrypt_ssl.sh` автоматически создаст доменное имя на основе вашего IP-адреса с помощью сервиса nip.io и получит для него доверенный SSL сертификат от Let's Encrypt.
+   > Скрипт `get_letsencrypt_ssl.sh` получит доверенный SSL сертификат от Let's Encrypt для домена h2o-nsk.ru.
 
 3. Собрать и запустить проект:
    ```bash
@@ -99,8 +99,8 @@ smart_carwash/
    ```
 
 5. Проверить работу приложения:
-   - Бэкенд API: https://158.160.105.190/api/wash-info
-   - Фронтенд: https://158.160.105.190
+   - Бэкенд API: https://h2o-nsk.ru/api/wash-info
+   - Фронтенд: https://h2o-nsk.ru
    - Telegram бот: https://t.me/carwash_grom_test_bot
 
 ### Управление проектом

--- a/smart_carwash/frontend/nginx.conf
+++ b/smart_carwash/frontend/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name h2o-nsk.ru;
     
     location / {
         root /usr/share/nginx/html;

--- a/smart_carwash/get_letsencrypt_ssl.sh
+++ b/smart_carwash/get_letsencrypt_ssl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Скрипт для получения SSL сертификата с помощью Let's Encrypt и сервиса nip.io
+# Скрипт для получения SSL сертификата с помощью Let's Encrypt для домена h2o-nsk.ru
 
 # Проверяем, установлен ли certbot
 if ! command -v certbot &> /dev/null; then
@@ -18,8 +18,8 @@ if [ -z "$SERVER_IP" ]; then
     exit 1
 fi
 
-# Создаем доменное имя на основе IP-адреса с помощью сервиса nip.io
-DOMAIN="${SERVER_IP}.nip.io"
+# Используем новый домен
+DOMAIN="h2o-nsk.ru"
 
 echo "Получаем SSL сертификат для домена: $DOMAIN (IP: $SERVER_IP)"
 
@@ -49,13 +49,13 @@ if sudo test -d "/etc/letsencrypt/live/$DOMAIN"; then
     sudo chmod 600 nginx/ssl/privkey.pem
     sudo chown $(whoami):$(whoami) nginx/ssl/fullchain.pem nginx/ssl/privkey.pem
     
-    # Обновляем .env файл, заменяя SERVER_IP на DOMAIN
+    # Обновляем .env файл, устанавливая новый домен
     echo "Обновляем .env файл..."
-    sed -i "s/SERVER_IP=$SERVER_IP/SERVER_IP=$DOMAIN/g" .env
+    sed -i "s/SERVER_IP=.*/SERVER_IP=$DOMAIN/g" .env
     
-    # Обновляем nginx.conf, заменяя IP-адрес на доменное имя
+    # Обновляем nginx.conf, устанавливая новый домен
     echo "Обновляем nginx.conf..."
-    sed -i "s/server_name $SERVER_IP;/server_name $DOMAIN;/g" nginx/nginx.conf
+    sed -i "s/server_name .*;/server_name $DOMAIN;/g" nginx/nginx.conf
     
     # Обновляем URL в боте
     echo "Обновляем URL в боте..."

--- a/smart_carwash/nginx/nginx.conf
+++ b/smart_carwash/nginx/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name 158.160.105.190.nip.io;
+    server_name h2o-nsk.ru;
     
     # Перенаправление на HTTPS
     location / {
@@ -10,7 +10,7 @@ server {
 
 server {
     listen 443 ssl;
-    server_name 158.160.105.190.nip.io;
+    server_name h2o-nsk.ru;
 
     # SSL сертификаты
     ssl_certificate /etc/nginx/ssl/fullchain.pem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions and example URLs in the README to use the fixed domain "h2o-nsk.ru" instead of dynamic IP-based domains.
- **Chores**
  - Updated configuration and scripts to use "h2o-nsk.ru" as the server domain for SSL certificates and Nginx settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->